### PR TITLE
Update installation of iptables-wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN (cd code && make build)
 
 FROM linuxserver/wireguard:${LSIO_WIREGUARD_TAG}
 
-COPY --from=build /go/code/iptables-wrapper-installer.sh /go/code/bin/iptables-wrapper /
-RUN apk add --no-cache nftables iptables-legacy && bash /iptables-wrapper-installer.sh
+COPY --from=build /go/code/bin/iptables-wrapper /
+RUN apk add --no-cache nftables iptables-legacy && /iptables-wrapper install


### PR DESCRIPTION
The bash script installer for iptables-wrapper was removed; `iptables-wrapper install` is the new method of installation.